### PR TITLE
Issue definitive API call to REDCap for downloading PDF run sheet

### DIFF
--- a/_find_eeg_event.py
+++ b/_find_eeg_event.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import json
+import sys
+from os.path import basename
+
+def get_value(var,event):
+
+    for d in dict1:
+        if d['redcap_event_name']==event:
+            try:
+                return d[var]
+            except KeyError:
+                return ''
+                
+    # the subject has not reached the event yet
+    return ''
+
+
+network=basename(sys.argv[1])
+_path=sys.argv[1]+'/PHOENIX/PROTECTED/'+sys.argv[2]
+sub=sys.argv[3]
+_date=sys.argv[4]
+date=_date[0:4]+'-'+_date[4:6]+'-'+_date[6:8]
+
+
+# provided path:
+# /data/predict1/data_from_nda/Pronet/PHOENIX/PROTECTED/PronetYA/processed/YA12345/eeg/ses-20230104/Figures
+# we need:
+# /data/predict1/data_from_nda/Pronet/PHOENIX/PROTECTED/PronetYA/raw/YA12345/surveys/YA12345.Pronet.json
+
+_path=_path.replace('processed','raw')
+_path=_path.split('eeg/ses-')[0]
+_path+=f'surveys/{sub}.{network}.json'
+
+with open(_path) as f:
+    dict1=json.load(f)
+    
+
+for e in 'baseline_arm_1,month_2_arm_1,baseline_arm_2,month_2_arm_2'.split(','):
+    chreeg_interview_date=get_value('chreeg_interview_date',e)
+    if chreeg_interview_date==date:
+        print(e)
+        break
+

--- a/down_eeg_pdf_rsheet.sh
+++ b/down_eeg_pdf_rsheet.sh
@@ -7,6 +7,8 @@ Provide REDCap token and /path/to/nda_root/network folder"""
     exit
 fi
 
+export PATH=/data/predict1/miniconda3/bin:$PATH
+
 TOKEN=$1
 # NETWORK_PHOENIX=/data/predict/data_from_nda/Pronet
 NETWORK_PHOENIX=$2/PHOENIX/PROTECTED/
@@ -33,7 +35,6 @@ do
     # find arm
     # _find_eeg_event.py network_directory figures_directory subject session(date)
     arm=`/data/predict1/eeg-qc-dash/_find_eeg_event.py $2 $d $sub $ses`
-    
 
     if [ -z $arm ]
     then


### PR DESCRIPTION
We determine the REDCap event name of an EEG session first. Then we issue the API call. Thus, we eliminate the need for making four blind API calls. Also, we shall not have to clean up any empty/broken run sheets after.